### PR TITLE
added tdd style asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,27 @@ compare object attributes and values rather than checking to see if they're the 
     subject.should.be.like({a: 'a'});
     subject.should.not.be.like({x: 'x'});
     subject.should.not.be.like({a: 'a', b: 'b'});
+
     expect(subject).to.be.like({a: 'a'});
     expect(subject).not.to.be.like({x: 'x'});
     expect(subject).not.to.be.like({a: 'a', b: 'b'});
 
+    assert.like(subject, {a: 'a'});
+    assert.notLike(subject, {x: 'x'});
+    assert.notLike(subject, {a: 'a', b: 'b'});
+	
     var subject = ['a'];
     subject.should.be.like(['a']);
     subject.should.not.be.like(['x']);
     subject.should.not.be.like(['a', 'b']);
+
     expect(subject).to.be.like(['a']);
     expect(subject).not.to.be.like(['x']);
     expect(subject).not.to.be.like(['a', 'b']);
+
+    assert.like(subject, ['a']);
+    assert.notLike(subject, ['x']);
+    assert.notLike(subject, ['a', 'b']);
 
 ## containOneLike(value)
 
@@ -77,8 +87,15 @@ check the first level of the container for a value like the one provided
         'scales', 'fins', 'cream'
       ]
     });
+
     subject.should.containOneLike('xylophone');
     subject.should.not.containOneLike('cow patties');
+
+    expect(subject).to.containOneLike('xylophone');
+    expect(subject).to.not.containOneLike('cow patties');
+
+    assert.containOneLike(subject, 'xylophone');
+    assert.notContainOneLike(subject, 'cow patties');
 
     // same for arrays
 
@@ -100,8 +117,15 @@ check that the given javascript object is like the JSON-ified expected value.  U
     };
     // here appleJSON would be the json result of some process like a JSON api
     var appleJSON  = JSON.parse(JSON.stringify(apple));
+
     appleJSON.should.be.jsonOf(apple);
     appleJSON.should.not.be.jsonOf(orange);
+
+    expect(appleJSON).to.be.jsonOf(apple);
+    expect(appleJSON).to.not.be.jsonOf(orange);
+
+    assert.jsonOf(appleJSON, apple);
+    assert.notJsonOf(appleJSON, orange);
 
 # Thanks
 

--- a/index.js
+++ b/index.js
@@ -86,4 +86,25 @@
       , expected
     )
   });
+
+  //export tdd style
+  var assert = chai.assert;
+  assert.like = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.be.like(exp);
+  };
+  assert.notLike = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.not.be.like(exp);
+  };
+  assert.containOneLike = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.containOneLike(exp);
+  };
+  assert.notContainOneLike = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.not.containOneLike(exp);
+  };
+  assert.jsonOf = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.be.jsonOf(exp);
+  };
+  assert.notJsonOf = function (val, exp, msg) {
+    new chai.Assertion(val, msg).to.not.be.jsonOf(exp);
+  };
 }));

--- a/test/chai-fuzzy.js
+++ b/test/chai-fuzzy.js
@@ -17,6 +17,7 @@
 }(function(chai, testingServer){
 
   var should = chai.should();
+  var assert = chai.assert;
 
   describe("chai-fuzzy", function() {
     if (testingServer) {
@@ -463,6 +464,47 @@
             });
           });
         }
+      });
+    });
+
+    describe("tdd alias", function() {
+      var objValue, objLike, objNotLike, objSub, objNotSub;
+
+      before(function(){
+        objValue = {a:1, b:2, c:[1,2,3]};
+        objLike = {c:[1,2,3], b:2, a:1};
+        objNotLike = {a:11, b:22, c:33};
+        objSub = [1,2,3];
+        objNotSub = [4,3,1];
+      });
+
+      //basic integrity checks
+
+      it(".like", function() {
+        assert.like(objValue, objLike ,'tdd');
+        objValue.should.be.like(objLike, 'bdd');
+      });
+      it(".notLike", function() {
+        assert.notLike(objValue, objNotLike ,'tdd');
+        objValue.should.not.be.like(objNotLike, 'bdd');
+      });
+
+      it(".jsonOf", function() {
+        assert.jsonOf(objValue, objLike ,'tdd');
+        objValue.should.be.jsonOf(objLike, 'bdd');
+      });
+      it(".notJsonOf", function() {
+        assert.notJsonOf(objValue, objNotLike ,'tdd');
+        objValue.should.not.be.jsonOf(objNotLike, 'bdd');
+      });
+
+      it(".containOneLike", function() {
+        assert.containOneLike(objValue, objSub ,'tdd');
+        objValue.should.containOneLike(objSub, 'bdd');
+      });
+      it(".notContainOneLike", function() {
+        assert.notContainOneLike(objValue, objNotLike ,'tdd');
+        objValue.should.not.containOneLike(objNotLike, 'bdd');
       });
     });
   });


### PR DESCRIPTION
I added tdd-style assert aliases for chai-fuzzy.

The test is simple and just to see if they exist and basically work like the bdd version. As the matcher itself is already fully tested I'm not really sure how far these need to go. 

Maybe you see a better pattern to add these alias integrity tests reliably? (without lame copy-paste errors etc)
