### PR TITLE
Depend on underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   },
   "author": "Elliot Foster",
   "license": "MIT",
+  "dependencies": {
+    "underscore": ">= 1.0.0"
+  },
   "devDependencies": {
     "chai": ">=1.0.0",
-    "mocha": ">=1.0.0",
-    "underscore": ">= 1.0.0"
+    "mocha": ">=1.0.0"
   },
   "peerDependencies": {
     "chai": ">= 1.0.0"


### PR DESCRIPTION
```sh
$ npm i chai-fuzzy --save-dev
$ echo 'chai.use(require("chai-fuzzy"));' >> fixtures.js
$ npm test
Error: Cannot find module 'underscore'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at /Users/robertcolburn/reflux-preload/node_modules/chai-fuzzy/index.js:32:9
    ...
```
:cry: :cry: